### PR TITLE
Enable Spotless linting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,19 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2023.3.2"
+    id "com.diffplug.spotless" version "6.21.0"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
 def ROBOT_MAIN_CLASS = "frc.robot.Main"
+
+spotless {
+  java {
+    googleJavaFormat()
+  }
+}
 
 // Define my targets (RoboRIO) and artifacts (deployable files)
 // This is added by GradleRIO's backing project DeployUtils.


### PR DESCRIPTION
This gradle plugin uses Google's Java Format standard to analyze our files and make sure they are in compliance, and will fail the build if best practices are not followed. It also allows us to automatically format the files to the new standard with the following command:

```
./gradlew spotlessApply
```